### PR TITLE
Revert:fix grub等待时间过长

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,7 +4,7 @@ Upstream-Contact:  UnionTech Software Technology Co., Ltd. <>
 Source: https://github.com/linuxdeepin/deepin-upgrade-manager
 
 # ci
-Files: .github/* .gitlab-ci.yml
+Files: .github/* .gitlab-ci.yml .obs/*
 Copyright: None
 License: CC0-1.0
 
@@ -30,7 +30,7 @@ Copyright: UnionTech Software Technology Co., Ltd.
 License: LGPL-3.0-or-later
 
 # Project file
-Files: Makefile .gitignore
+Files: Makefile .gitignore go.mod go.sum
 Copyright: None
 License: CC0-1.0
 

--- a/cmd/deepin-upgrade-manager/main.go
+++ b/cmd/deepin-upgrade-manager/main.go
@@ -135,10 +135,10 @@ func handleAction(m *upgrader.Upgrader, c *config.Config) {
 			logger.Error("must special version")
 			os.Exit(FAILED_VERSION_EXISTS)
 		}
-		err := m.Snapshot(*_version)
+		exCode, err := m.EnableBoot(*_version)
 		if err != nil {
 			logger.Errorf("snapshot %q: %v", *_version, err)
-			os.Exit(int(FAILED_VERSION_EXISTS))
+			os.Exit(int(exCode))
 		}
 	case _ACTION_BOOTLIST:
 		// close log

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-upgrade-manager (1.0.18) unstable; urgency=medium
+
+  * Revert:fix grub waiting too long.
+
+ -- LiChengGang <lichenggang@uniontech.com>  Mon, 17 Apr 2023 16:49:04 +0800
+
 deepin-upgrade-manager (1.0.17) unstable; urgency=medium
 
   * Feat create rootfs in maximum partition function

--- a/pkg/module/repo/ostree/ostree.go
+++ b/pkg/module/repo/ostree/ostree.go
@@ -112,16 +112,6 @@ func (repo *OSTree) Snapshot(branchName, dstDir string) error {
 	return err
 }
 
-func (repo *OSTree) SnapshotSub(branchName, subDir, dstDir string) error {
-	if !repo.Exist(branchName) {
-		return fmt.Errorf("not found the branchName: %s", branchName)
-	}
-	_ = os.MkdirAll(filepath.Dir(dstDir), 0600)
-	_, err := doAction([]string{"checkout", "--repo=" + repo.repoDir, "--subpath=" + subDir,
-		branchName, dstDir})
-	return err
-}
-
 func (repo *OSTree) Commit(branchName, subject, dataDir string) error {
 	if !branch.IsValid(branchName) {
 		return fmt.Errorf("invalid branch name: %s", branchName)

--- a/pkg/module/repo/repo.go
+++ b/pkg/module/repo/repo.go
@@ -18,7 +18,6 @@ type Repository interface {
 	List() (branch.BranchList, error)
 	ListByName(branchName string, offset, limit int) (branch.BranchList, int, error)
 	Snapshot(branchName, dstDir string) error
-	SnapshotSub(branchName, subDir, dstDir string) error
 	Commit(branchName, subject, dataDir string) error
 	Diff(baseBranch, targetBranch, dstFile string) error
 	Cat(branchName, filepath, dstFile string) error

--- a/pkg/upgrader/upgrader.go
+++ b/pkg/upgrader/upgrader.go
@@ -379,7 +379,7 @@ func (c *Upgrader) UpdateGrub() (stateType, error) {
 
 func (c *Upgrader) EnableBoot(version string) (stateType, error) {
 	exitCode := _STATE_TY_SUCCESS
-	err := c.repoSnapShotSubDir(c.conf.RepoList[0], "/boot", version)
+	err := c.Snapshot(version)
 	if err != nil {
 		exitCode = _STATE_TY_FAILED_NO_REPO
 		return exitCode, err
@@ -767,15 +767,8 @@ func (c *Upgrader) repoSnapShot(repoConf *config.RepoConfig, version string) err
 	return handler.Snapshot(version, dataDir)
 }
 
-func (c *Upgrader) repoSnapShotSubDir(repoConf *config.RepoConfig, subDir, version string) error {
-	handler := c.repoSet[repoConf.Repo]
-	dataDir := filepath.Join(c.rootMP, repoConf.SnapshotDir, version)
-	_ = os.RemoveAll(dataDir)
-	return handler.SnapshotSub(version, subDir, dataDir)
-}
-
 func (c *Upgrader) enableSnapshotBoot(snapDir, version string) error {
-	bootDir := snapDir
+	bootDir := filepath.Join(snapDir, "boot")
 	fiList, err := ioutil.ReadDir(bootDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
  Revert fix grub等待时间过长 该笔提交导致升级工具无法正常工作 暂时回退处理

Log:   Revert 2e26ae67571b716b478cbb4b34ae042197c753fa
