### PR TITLE
Reduce /boot partition usage by adjusting max_version_retention

### DIFF
--- a/configs/upgrader/config.simple.json
+++ b/configs/upgrader/config.simple.json
@@ -5,7 +5,7 @@
   "cache_dir": "/usr/.osrepo-cache",
   "auto_cleanup": true,
   "max_repo_retention": 3,
-  "max_version_retention": 5,
+  "max_version_retention": 2,
   "repo_list": [
     {
       "repo_mount_point":"/persistent",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+deepin-upgrade-manager (1.0.27) unstable; urgency=medium
+
+  * Reduced MaxVersionRetention from 5 to 2.
+    Previously, with MaxVersionRetention set to 5, the /boot/ partition could
+    retain up to 5 versions of kernel and initramfs files. Assuming each
+    version's kernel and initramfs files together occupy 100MB, this would
+    result in:
+
+    5 versions × 3 kernels × 100 MB = 1.5 GB
+
+    Given that our default /boot partition size is 1.5GB, this configuration
+    would lead to insufficient space, causing update failures and other
+    issues.
+
+    This change helps prevent the /boot/ partition from running out of space
+    by limiting the number of retained kernel and initramfs versions.
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Thu, 16 May 2024 17:41:46 +0800
+
 deepin-upgrade-manager (1.0.26) unstable; urgency=medium
 
   * Allow customizing theme


### PR DESCRIPTION
- Changed max_version_retention from 5 to 2 to address space issues in the /boot partition.
- Calculated that retaining 5 versions of kernel and initramfs files could occupy up to 1.5GB, which matches the default /boot partition size, leading to potential space shortages.

This change ensures that systems with a default /boot partition size of 1.5GB will have sufficient space for updates, reducing the likelihood of update failures and improving overall system reliability.
